### PR TITLE
Fix invalid url in lab2

### DIFF
--- a/tutorials/lab2-application-and-service.md
+++ b/tutorials/lab2-application-and-service.md
@@ -1508,7 +1508,7 @@ how.nice.to.look=fairlyNice
 
 ## Readings
 
-* [kubernetes configmap](https://kubernetes.io/docs/tasks/configure-pod-container/configmap/)
+* [kubernetes configmap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
 * [distribute secret](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/)
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

[lab2 kubernetes-configmap-secret](https://github.com/caicloud/kube-ladder/blob/master/tutorials/lab2-application-and-service.md#kubernetes-configmap--secret), Readings url about `kubernetes configmap` is invalid.