### PR TITLE
fix a typo and add notes in lab3

### DIFF
--- a/tutorials/lab3-manual-installtion.md
+++ b/tutorials/lab3-manual-installtion.md
@@ -1013,7 +1013,7 @@ etcd-0               Healthy   {"health":"true"}
 
 本节将会配置 API Server 访问 Kubelet API 的 RBAC 授权。访问 Kubelet API 是获取 metrics、日志以及执行容器命令所必需的。
 
-> 这里设置 Kubeket `--authorization-mode` 为 `Webhook` 模式。Webhook 模式使用 [SubjectAccessReview](https://kubernetes.io/docs/admin/authorization/#checking-api-access) API 来决定授权。
+> 这里设置 Kubelet `--authorization-mode` 为 `Webhook` 模式。Webhook 模式使用 [SubjectAccessReview](https://kubernetes.io/docs/admin/authorization/#checking-api-access) API 来决定授权。
 
 创建 `system:kube-apiserver-to-kubelet` [ClusterRole](https://kubernetes.io/docs/admin/authorization/rbac/#role-and-clusterrole) 以允许请求 Kubelet API 和执行大部分来管理 Pods 的任务:
 

--- a/tutorials/lab3-manual-installtion.md
+++ b/tutorials/lab3-manual-installtion.md
@@ -786,6 +786,8 @@ ETCD_NAME=$(hostname -s)
 
 生成 `etcd.service` 的 systemd 配置文件
 
+*请注意：对于使用公网主机（如云服务器等）的操作者， etcd 绑定的服务端口（即以下的 `${MASTER_IP}` ）应使用内网 IP 地址。*
+
 ```sh
 cat <<EOF | sudo tee /etc/systemd/system/etcd.service
 [Unit]


### PR DESCRIPTION
**What this PR does / why we need it**:

fix a typo and add notes in lab3:

1. Typo: kubeket -> kubelet

2. For public network hosts, users are prompted to use intranet IP when configuring etcd

Thanks for your review.


**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:

```
NONE
```
